### PR TITLE
Update egg-m-c-xbox-broadcast.json

### DIFF
--- a/egg-m-c-xbox-broadcast.json
+++ b/egg-m-c-xbox-broadcast.json
@@ -16,7 +16,7 @@
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{}",
-        "startup": "{\r\n    \"done\": \"Created session!\"\r\n}",
+        "startup": "{\r\n    \"done\": \"Creation of Xbox LIVE session was successful!\"\r\n}",
         "logs": "{}",
         "stop": "exit"
     },


### PR DESCRIPTION
Fixed a problem in which different messages at startup did not result in a judgment that the startup was successful.