### PR TITLE
Updated MinecraftAuth API usage

### DIFF
--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/AuthManager.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/AuthManager.java
@@ -4,17 +4,10 @@ import com.google.gson.JsonObject;
 import com.rtm516.mcxboxbroadcast.core.models.auth.XboxTokenInfo;
 import net.lenni0451.commons.httpclient.HttpClient;
 import net.raphimc.minecraftauth.MinecraftAuth;
-import net.raphimc.minecraftauth.step.msa.MsaCodeStep;
 import net.raphimc.minecraftauth.step.msa.StepMsaDeviceCode;
-import net.raphimc.minecraftauth.step.msa.StepMsaDeviceCodeMsaCode;
 import net.raphimc.minecraftauth.step.msa.StepMsaToken;
-import net.raphimc.minecraftauth.step.msa.StepRefreshTokenMsaCode;
-import net.raphimc.minecraftauth.step.xbl.StepXblDeviceToken;
 import net.raphimc.minecraftauth.step.xbl.StepXblSisuAuthentication;
-import net.raphimc.minecraftauth.step.xbl.session.StepInitialXblSession;
 import net.raphimc.minecraftauth.util.JsonUtil;
-import net.raphimc.minecraftauth.util.MicrosoftConstants;
-import net.raphimc.minecraftauth.util.OAuthEnvironment;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -51,13 +44,7 @@ public class AuthManager {
      * Follow the auth flow to get the Xbox token and store it
      */
     private void initialise() {
-        // Setup the authentication steps
         HttpClient httpClient = MinecraftAuth.createHttpClient();
-        MsaCodeStep.ApplicationDetails appDetails = new MsaCodeStep.ApplicationDetails(MicrosoftConstants.BEDROCK_ANDROID_TITLE_ID, MicrosoftConstants.SCOPE_TITLE_AUTH, null, null, OAuthEnvironment.LIVE);
-        StepMsaToken initialAuth = new StepMsaToken(new StepMsaDeviceCodeMsaCode(new StepMsaDeviceCode(appDetails), 120 * 1000));
-        StepInitialXblSession xblAuth = new StepInitialXblSession(initialAuth, new StepXblDeviceToken("Android"));
-        StepXblSisuAuthentication xstsAuth = new StepXblSisuAuthentication(xblAuth, MicrosoftConstants.XBL_XSTS_RELYING_PARTY);
-
         // Check if we have an old live_token.json file and try to import the refresh token from it
         if (Files.exists(oldLiveAuth)) {
             logger.info("Trying to convert from old live_token.json to new cache.json");
@@ -65,11 +52,7 @@ public class AuthManager {
                 JsonObject liveToken = JsonUtil.parseString(Files.readString(oldLiveAuth)).getAsJsonObject();
                 JsonObject tokenData = liveToken.getAsJsonObject("token");
 
-                StepMsaToken convertInitialAuth = new StepMsaToken(new StepRefreshTokenMsaCode(appDetails));
-                StepInitialXblSession convertXblAuth = new StepInitialXblSession(convertInitialAuth, new StepXblDeviceToken("Android"));
-                StepXblSisuAuthentication convertXstsAuth = new StepXblSisuAuthentication(convertXblAuth, MicrosoftConstants.XBL_XSTS_RELYING_PARTY);
-
-                xstsToken = convertXstsAuth.getFromInput(httpClient, new StepRefreshTokenMsaCode.RefreshToken(tokenData.get("refresh_token").getAsString()));
+                xstsToken = MinecraftAuth.BEDROCK_XBL_DEVICE_CODE_LOGIN.getFromInput(httpClient, new StepMsaToken.RefreshToken(tokenData.get("refresh_token").getAsString()));
 
                 Files.delete(oldLiveAuth);
                 if (Files.exists(oldXboxAuth)) Files.delete(oldXboxAuth);
@@ -80,7 +63,7 @@ public class AuthManager {
 
         // Load in cache.json if we haven't loaded one from the old auth token
         try {
-            if (xstsToken == null && Files.exists(cache)) xstsToken = xstsAuth.fromJson(JsonUtil.parseString(Files.readString(cache)).getAsJsonObject());
+            if (xstsToken == null && Files.exists(cache)) xstsToken = MinecraftAuth.BEDROCK_XBL_DEVICE_CODE_LOGIN.fromJson(JsonUtil.parseString(Files.readString(cache)).getAsJsonObject());
         } catch (IOException e) {
             logger.error("Failed to load cache.json", e);
         }
@@ -88,15 +71,15 @@ public class AuthManager {
         try {
             // Get the XSTS token or refresh it if it's expired
             if (xstsToken == null) {
-                xstsToken = xstsAuth.getFromInput(httpClient, new StepMsaDeviceCode.MsaDeviceCodeCallback(msaDeviceCode -> {
+                xstsToken = MinecraftAuth.BEDROCK_XBL_DEVICE_CODE_LOGIN.getFromInput(httpClient, new StepMsaDeviceCode.MsaDeviceCodeCallback(msaDeviceCode -> {
                     logger.info("To sign in, use a web browser to open the page " + msaDeviceCode.getVerificationUri() + " and enter the code " + msaDeviceCode.getUserCode() + " to authenticate.");
                 }));
             } else if (xstsToken.isExpired()) {
-                xstsToken = xstsAuth.refresh(httpClient, xstsToken);
+                xstsToken = MinecraftAuth.BEDROCK_XBL_DEVICE_CODE_LOGIN.refresh(httpClient, xstsToken);
             }
 
             // Save to cache.json
-            Files.writeString(cache, JsonUtil.GSON.toJson(xstsAuth.toJson(xstsToken)));
+            Files.writeString(cache, JsonUtil.GSON.toJson(MinecraftAuth.BEDROCK_XBL_DEVICE_CODE_LOGIN.toJson(xstsToken)));
 
             // Construct and store the Xbox token info
             xboxTokenInfo = new XboxTokenInfo(xstsToken.getDisplayClaims().get("xid"), xstsToken.getUserHash(), xstsToken.getDisplayClaims().get("gtg"), xstsToken.getToken(), String.valueOf(xstsToken.getExpireTimeMs()));


### PR DESCRIPTION
I improved MinecraftAuth, so its nicer to use for interacting with the Xbox Live API. Notably I did the following:
* I added MinecraftAuth.BEDROCK_XBL_DEVICE_CODE_LOGIN because there are now 2 people needing that
* All login flows now accept a RefreshToken in getFromInput which allows you to create different token chains without requiring another login

This PR is untested.