### PR TITLE
Null-safe removeColorCodes in SessionInfo

### DIFF
--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SessionInfo.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SessionInfo.java
@@ -105,6 +105,9 @@ public class SessionInfo {
     }
 
     private static String removeColorCodes(String string) {
+        if (string == null) {
+            return "";
+        }
         Matcher matcher = COLOR_PATTERN.matcher(string);
         return matcher.replaceAll("");
     }


### PR DESCRIPTION
## Summary

`SessionInfo.removeColorCodes` calls `Pattern.matcher(string)` with no null check, so any `setHostName(null)` / `setWorldName(null)` crashes the process with an NPE. This happens in practice when `pong.subMotd()` returns null — observed running build 142 against `itzg/minecraft-bedrock-server` (Bedrock 1.26.21):

```
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "java.lang.CharSequence.length()" because "this.text" is null
	at java.base/java.util.regex.Matcher.getTextLength(Matcher.java:1808)
	at java.base/java.util.regex.Matcher.reset(Matcher.java:461)
	at java.base/java.util.regex.Matcher.<init>(Matcher.java:256)
	at java.base/java.util.regex.Pattern.matcher(Pattern.java:1180)
	at com.rtm516.mcxboxbroadcast.core.SessionInfo.removeColorCodes(SessionInfo.java:108)
	at com.rtm516.mcxboxbroadcast.core.SessionInfo.setHostName(SessionInfo.java:44)
	at com.rtm516.mcxboxbroadcast.bootstrap.standalone.StandaloneMain.updateSessionInfo(StandaloneMain.java:118)
	at com.rtm516.mcxboxbroadcast.bootstrap.standalone.StandaloneMain.main(StandaloneMain.java:64)
```

`StandaloneMain.updateSessionInfo` already has an empty-string fallback path immediately after these setters:

```java
if (sessionInfo.getHostName().isEmpty()) {
    sessionInfo.setHostName(sessionManager.getGamertag());
}
```

…so the intent is clearly that a missing host name should fall back to the gamertag. Treating `null` as `""` inside `removeColorCodes` lets that existing fallback do its job for both setters instead of crashing the process before it can run.
