### PR TITLE
Add configurable WebRTC ICE port range

### DIFF
--- a/bootstrap/geyser/src/main/java/com/rtm516/mcxboxbroadcast/bootstrap/geyser/MCXboxBroadcastExtension.java
+++ b/bootstrap/geyser/src/main/java/com/rtm516/mcxboxbroadcast/bootstrap/geyser/MCXboxBroadcastExtension.java
@@ -120,6 +120,7 @@ public class MCXboxBroadcastExtension implements Extension {
 
         // Create a new session manager, but reuse the notification manager as config hasn't been reloaded
         sessionManager = new SessionManager(new FileStorageManager(this.dataFolder().toString(), this.dataFolder().resolve("screenshot.jpg").toString()), notificationManager, logger);
+        sessionManager.setNetherNetPortRange(config.session().icePortRange().min(), config.session().icePortRange().max());
 
         // Pull onto another thread so we don't hang the main thread
         sessionManager.scheduledThread().execute(this::createSession);
@@ -156,6 +157,7 @@ public class MCXboxBroadcastExtension implements Extension {
 
         // Create the session manager
         sessionManager = new SessionManager(new FileStorageManager(this.dataFolder().toString(), this.dataFolder().resolve("screenshot.jpg").toString()), notificationManager, logger);
+        sessionManager.setNetherNetPortRange(config.session().icePortRange().min(), config.session().icePortRange().max());
 
         // Pull onto another thread so we don't hang the main thread
         sessionManager.scheduledThread().execute(() -> {

--- a/bootstrap/standalone/src/main/java/com/rtm516/mcxboxbroadcast/bootstrap/standalone/StandaloneMain.java
+++ b/bootstrap/standalone/src/main/java/com/rtm516/mcxboxbroadcast/bootstrap/standalone/StandaloneMain.java
@@ -50,6 +50,7 @@ public class StandaloneMain {
         notificationManager = new SlackNotificationManager(logger, config.notifications());
 
         sessionManager = new SessionManager(new FileStorageManager("./cache", "./screenshot.jpg"), notificationManager, logger);
+        sessionManager.setNetherNetPortRange(config.session().icePortRange().min(), config.session().icePortRange().max());
 
         sessionInfo = new SessionInfo(config.session().sessionInfo());
 
@@ -74,6 +75,7 @@ public class StandaloneMain {
 
             // Create a new session manager, but reuse the notification manager as config hasn't been reloaded
             sessionManager = new SessionManager(new FileStorageManager("./cache", "./screenshot.jpg"), notificationManager, logger);
+            sessionManager.setNetherNetPortRange(config.session().icePortRange().min(), config.session().icePortRange().max());
 
             createSession();
         } catch (SessionCreationException | SessionUpdateException e) {

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SessionManagerCore.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SessionManagerCore.java
@@ -14,8 +14,10 @@ import com.rtm516.mcxboxbroadcast.core.notifications.NotificationManager;
 import com.rtm516.mcxboxbroadcast.core.storage.StorageManager;
 import com.rtm516.mcxboxbroadcast.core.nethernet.BroadcasterChannelInitializer;
 import dev.kastle.netty.channel.nethernet.NetherNetChannelFactory;
+import dev.kastle.netty.channel.nethernet.config.NetherChannelOption;
 import dev.kastle.netty.channel.nethernet.signaling.NetherNetXboxRpcSignaling;
 import dev.kastle.webrtc.PeerConnectionFactory;
+import dev.kastle.webrtc.PortAllocatorConfig;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
@@ -58,6 +60,8 @@ public abstract class SessionManagerCore {
     private EventLoopGroup bossGroup;
     private EventLoopGroup workerGroup;
     private NetherNetXboxRpcSignaling signaling;
+
+    private PortAllocatorConfig netherNetPortAllocatorConfig;
 
     /**
      * Create an instance of SessionManager
@@ -421,6 +425,43 @@ public abstract class SessionManagerCore {
         rtaWebsocket.connect();
     }
 
+    /**
+     * Restrict the local UDP port range used for WebRTC (NetherNet) ICE candidates.
+     * Passing 0 for both min and max keeps the transport default (the OS ephemeral
+     * range).
+     *
+     * @param min The lowest UDP port to use, or 0 for the OS default
+     * @param max The highest UDP port to use, or 0 for the OS default
+     */
+    public void setNetherNetPortRange(int min, int max) {
+        if (min <= 0 && max <= 0) {
+            this.netherNetPortAllocatorConfig = null;
+            return;
+        }
+
+        // Setting the channel option replaces the whole PortAllocatorConfig, so the
+        // transport's default flags (see DefaultNetherChannelConfig) are mirrored
+        // here and only the port range is overridden.
+        PortAllocatorConfig config = new PortAllocatorConfig()
+            .setDisableTcp(true)
+            .setEnableIpv6(true)
+            .setEnableIpv6OnWifi(true)
+            .setEnableAnyAddressPorts(true)
+            .setEnableSharedSocket(true);
+        config.minPort = min;
+        config.maxPort = max;
+
+        this.netherNetPortAllocatorConfig = config;
+    }
+
+    /**
+     * @return The WebRTC port allocator config to use for NetherNet, or null to use
+     *         the transport default
+     */
+    protected PortAllocatorConfig netherNetPortAllocatorConfig() {
+        return netherNetPortAllocatorConfig;
+    }
+
     protected void setupNetherNet() {
         shutdownNetherNet();
 
@@ -438,9 +479,17 @@ public abstract class SessionManagerCore {
                 .channelFactory(NetherNetChannelFactory.server(new PeerConnectionFactory(), signaling))
                 .childHandler(new BroadcasterChannelInitializer(sessionInfo, this, logger));
 
+            PortAllocatorConfig portAllocatorConfig = netherNetPortAllocatorConfig();
+            if (portAllocatorConfig != null) {
+                b.option(NetherChannelOption.NETHER_PORT_ALLOCATOR_CONFIG, portAllocatorConfig);
+            }
+
             this.netherNetChannel = b.bind(new InetSocketAddress(0)).sync().channel();
 
-            logger.info("NetherNet Broadcaster started on ID: " + netherNetId);
+            logger.info("NetherNet Broadcaster started on ID: " + netherNetId
+                + (portAllocatorConfig != null
+                    ? " (ICE ports " + portAllocatorConfig.minPort + "-" + portAllocatorConfig.maxPort + ")"
+                    : ""));
         } catch (Exception e) {
             logger.error("Failed to start NetherNet", e);
         }

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SubSessionManager.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SubSessionManager.java
@@ -4,6 +4,7 @@ import com.rtm516.mcxboxbroadcast.core.exceptions.SessionUpdateException;
 import com.rtm516.mcxboxbroadcast.core.models.session.JoinSessionRequest;
 import com.rtm516.mcxboxbroadcast.core.notifications.NotificationManager;
 import com.rtm516.mcxboxbroadcast.core.storage.StorageManager;
+import dev.kastle.webrtc.PortAllocatorConfig;
 
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -30,6 +31,11 @@ public class SubSessionManager extends SessionManagerCore {
     @Override
     public ScheduledExecutorService scheduledThread() {
         return parent.scheduledThread();
+    }
+
+    @Override
+    protected PortAllocatorConfig netherNetPortAllocatorConfig() {
+        return parent.netherNetPortAllocatorConfig();
     }
 
     @Override

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/configs/CoreConfig.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/configs/CoreConfig.java
@@ -80,12 +80,11 @@ public interface CoreConfig {
         SessionInfo sessionInfo();
 
         @Comment("""
-            Restrict the local UDP port range used for WebRTC (NetherNet) ICE candidates.
-            Useful when running behind a firewall or in Docker with host networking, so
-            only a small range needs to be opened. Each in-progress join uses one port
-            from the range (freed once the player is transferred), so the range caps how
-            many players can be joining at the same moment, not the total player count.
-            Leave both at 0 to use the operating system's ephemeral range (default).""")
+            Restrict the local UDP port range for WebRTC (NetherNet) ICE candidates,
+            so only a small range needs opening behind a firewall or in Docker with
+            host networking. Each in-progress join uses one port (freed once the player
+            is transferred), so this caps concurrent joins, not total players.
+            Leave both at 0 for the OS ephemeral range (default).""")
         IcePortRange icePortRange();
 
         @ConfigSerializable

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/configs/CoreConfig.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/configs/CoreConfig.java
@@ -79,6 +79,26 @@ public interface CoreConfig {
         @ExcludePlatform(platforms = {"Extension"})
         SessionInfo sessionInfo();
 
+        @Comment("""
+            Restrict the local UDP port range used for WebRTC (NetherNet) ICE candidates.
+            Useful when running behind a firewall or in Docker with host networking, so
+            only a small range needs to be opened. Leave both at 0 to use the operating
+            system's ephemeral range (the default behaviour).""")
+        IcePortRange icePortRange();
+
+        @ConfigSerializable
+        interface IcePortRange {
+            @Comment("Lowest UDP port to use, or 0 for the OS default")
+            @DefaultNumeric(0)
+            @NumericRange(from = 0, to = 65535)
+            int min();
+
+            @Comment("Highest UDP port to use, or 0 for the OS default")
+            @DefaultNumeric(0)
+            @NumericRange(from = 0, to = 65535)
+            int max();
+        }
+
         @ConfigSerializable
         interface SessionInfo {
             @Comment("The host name to broadcast")

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/configs/CoreConfig.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/configs/CoreConfig.java
@@ -82,8 +82,10 @@ public interface CoreConfig {
         @Comment("""
             Restrict the local UDP port range used for WebRTC (NetherNet) ICE candidates.
             Useful when running behind a firewall or in Docker with host networking, so
-            only a small range needs to be opened. Leave both at 0 to use the operating
-            system's ephemeral range (the default behaviour).""")
+            only a small range needs to be opened. Each in-progress join uses one port
+            from the range (freed once the player is transferred), so the range caps how
+            many players can be joining at the same moment, not the total player count.
+            Leave both at 0 to use the operating system's ephemeral range (default).""")
         IcePortRange icePortRange();
 
         @ConfigSerializable


### PR DESCRIPTION
NetherNet uses WebRTC, which gathers ICE candidates from the OS ephemeral port range by default. When running behind a firewall or in Docker with host networking, that forces opening a very large UDP range.

This adds an optional `session.ice-port-range` config with `min`/`max` to pin the WebRTC ICE candidate ports:

```yaml
session:
  ice-port-range:
    min: 0   # 0 = OS ephemeral (default)
    max: 0
```