### PR TITLE
Detects expired Microsoft auth 

### DIFF
--- a/bootstrap/standalone/src/main/java/com/rtm516/mcxboxbroadcast/bootstrap/standalone/StandaloneMain.java
+++ b/bootstrap/standalone/src/main/java/com/rtm516/mcxboxbroadcast/bootstrap/standalone/StandaloneMain.java
@@ -91,6 +91,12 @@ public class StandaloneMain {
             return;
         }
 
+        if (sessionManager.consumeAuthRecoveryFlag()) {
+            logger.info("Re-auth completed; restarting session to refresh NetherNet...");
+            restart();
+            return;
+        }
+
         sessionManager.scheduledThread().scheduleWithFixedDelay(() -> {
             updateSessionInfo(sessionInfo);
 

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/AuthManager.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/AuthManager.java
@@ -18,6 +18,7 @@ import net.raphimc.minecraftauth.util.holder.listener.BasicChangeListener;
 import net.raphimc.minecraftauth.util.http.exception.InformativeHttpRequestException;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.function.Consumer;
 
 public class AuthManager {
@@ -27,6 +28,7 @@ public class AuthManager {
 
     private BedrockAuthManager authManager;
     private Runnable onDeviceTokenRefreshCallback;
+    private boolean recoveredExpiredGrant;
 
     private final Holder<CachedProfileInfo> profileInfo;
 
@@ -87,14 +89,7 @@ public class AuthManager {
         try {
             // Login if not already loaded
             if (authManager == null) {
-                // Explicitly define the callback to assist type inference for the generic T
-                Consumer<MsaDeviceCode> deviceCodeCallback = msaDeviceCode -> {
-                    logger.info("To sign in, use a web browser to open the page " + msaDeviceCode.getVerificationUri() + " and enter the code " + msaDeviceCode.getUserCode() + " to authenticate.");
-                    notificationManager.sendSessionExpiredNotification(msaDeviceCode.getVerificationUri(), msaDeviceCode.getUserCode());
-                };
-
-                authManager = BedrockAuthManager.create(httpClient, Constants.BEDROCK_CODEC.getMinecraftVersion())
-                        .login(DeviceCodeMsaAuthService::new, deviceCodeCallback);
+                loginWithDeviceCode(httpClient);
             }
 
             // Ensure tokens are fresh
@@ -116,8 +111,65 @@ public class AuthManager {
                 return;
             }
 
+            if (isExpiredGrant(e)) {
+                recoverExpiredGrant(httpClient, e);
+                return;
+            }
+
             logger.error("Failed to get/refresh auth token", e);
         }
+    }
+
+    private void loginWithDeviceCode(HttpClient httpClient) throws Exception {
+        // Explicitly define the callback to assist type inference for the generic T
+        Consumer<MsaDeviceCode> deviceCodeCallback = msaDeviceCode -> {
+            logger.info("To sign in, use a web browser to open the page " + msaDeviceCode.getVerificationUri() + " and enter the code " + msaDeviceCode.getUserCode() + " to authenticate.");
+            notificationManager.sendSessionExpiredNotification(msaDeviceCode.getVerificationUri(), msaDeviceCode.getUserCode());
+        };
+
+        authManager = BedrockAuthManager.create(httpClient, Constants.BEDROCK_CODEC.getMinecraftVersion())
+                .login(DeviceCodeMsaAuthService::new, deviceCodeCallback);
+    }
+
+    private void recoverExpiredGrant(HttpClient httpClient, Exception originalError) {
+        logger.warn("Re-auth required: saved Microsoft/Xbox login expired. Sign in again to continue.");
+
+        authManager = null;
+        try {
+            storageManager.cache("");
+        } catch (IOException e) {
+            logger.error("Failed to clear expired auth cache", e);
+        }
+
+        try {
+            loginWithDeviceCode(httpClient);
+            refreshTokens();
+            authManager.getChangeListeners().add((BasicChangeListener) this::saveToCache);
+            saveToCache();
+
+            if (onDeviceTokenRefreshCallback != null) {
+                authManager.getXblDeviceToken().getChangeListeners().add((BasicChangeListener) onDeviceTokenRefreshCallback::run);
+            }
+
+            recoveredExpiredGrant = true;
+        } catch (Exception e) {
+            logger.error("Failed to re-authorize Xbox account after expired login", e);
+            logger.debug("Original expired login error: " + originalError.getMessage());
+        }
+    }
+
+    private boolean isExpiredGrant(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            String message = String.valueOf(current.getMessage()).toLowerCase(Locale.ROOT);
+            if (message.contains("invalid_grant")
+                    || message.contains("grant is expired")
+                    || message.contains("must sign in again")) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 
     private void refreshTokens() throws IOException, AgeVerificationException {
@@ -163,6 +215,12 @@ public class AuthManager {
             initialise();
         }
         return authManager;
+    }
+
+    public boolean consumeRecoveredExpiredGrant() {
+        boolean recovered = recoveredExpiredGrant;
+        recoveredExpiredGrant = false;
+        return recovered;
     }
 
     public String getPlayfabSessionTicket() {

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/Constants.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/Constants.java
@@ -3,7 +3,7 @@ package com.rtm516.mcxboxbroadcast.core;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.cloudburstmc.protocol.bedrock.codec.BedrockCodec;
-import org.cloudburstmc.protocol.bedrock.codec.v975.Bedrock_v975;
+import org.cloudburstmc.protocol.bedrock.codec.v1001.Bedrock_v1001;
 
 import java.net.URI;
 import java.time.Duration;
@@ -51,7 +51,7 @@ public class Constants {
     /**
      * Used for the micro nethernet server that transfers the client to the real server
      */
-    public static final BedrockCodec BEDROCK_CODEC = Bedrock_v975.CODEC;
+    public static final BedrockCodec BEDROCK_CODEC = Bedrock_v1001.CODEC;
 
     /**
      * Config version for upgrade purposes

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/FriendManager.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/FriendManager.java
@@ -288,6 +288,8 @@ public class FriendManager {
         if (friendSyncConfig.autoFollow() || friendSyncConfig.autoUnfollow()) {
             sessionManager.scheduledThread().scheduleWithFixedDelay(() -> {
                 try {
+                    acceptPendingFriendRequests();
+
                     for (FollowerResponse.Person person : get()) {
                         // Make sure we are not targeting a subaccount (eg: split screen)
                         if (isGuestAccount(person.xuid)) {

--- a/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SessionManagerCore.java
+++ b/core/src/main/java/com/rtm516/mcxboxbroadcast/core/SessionManagerCore.java
@@ -143,6 +143,10 @@ public abstract class SessionManagerCore {
         return authManager.getManager();
     }
 
+    public boolean consumeAuthRecoveryFlag() {
+        return authManager.consumeRecoveredExpiredGrant();
+    }
+
     /**
      * Initialize the session manager with the given session information
      *

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ sqlite = "3.50.2.0"
 webrtc = "1.0.4"
 configurate = "4.2.0-GeyserMC-20251111.004649-11"
 configurate-core = "4.2.0-GeyserMC-20251111.004649-12"
-netty-transport-nethernet = "1.7.0"
+netty-transport-nethernet = "1.7.1"
 
 shadow = "9.3.0"
 indra = "3.1.3"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ sqlite = "3.50.2.0"
 webrtc = "1.0.4"
 configurate = "4.2.0-GeyserMC-20251111.004649-11"
 configurate-core = "4.2.0-GeyserMC-20251111.004649-12"
-netty-transport-nethernet = "1.7.1"
+netty-transport-nethernet = "1.7.2"
 
 shadow = "9.3.0"
 indra = "3.1.3"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-protocol-connection = "3.0.0.Beta12-20260505.144358-18"
-protocol-common = "3.0.0.Beta12-20260505.144358-18"
-protocol-codec = "3.0.0.Beta12-20260505.144358-18"
+protocol-connection = "3.0.0.Beta12-20260609.111529-27"
+protocol-common = "3.0.0.Beta12-20260609.111529-27"
+protocol-codec = "3.0.0.Beta12-20260609.111529-26"
 geyser ="2.9.3-SNAPSHOT"
 java-websocket = "1.5.3"
 nimbus-jose-jwt = "9.23"


### PR DESCRIPTION
[AuthManager.java (line 123)]
Detects expired Microsoft auth grant text, clears stale cache.json, forces the device-code login flow, logs Re-auth required, saves the fresh auth cache, and exposes a one-shot recovery flag.

[SessionManagerCore.java (line 146)]
Exposes consumeAuthRecoveryFlag() so bootstraps can react after auth recovery.

[StandaloneMain.java (line 94)]
If auth was recovered, it restarts the standalone session immediately to refresh NetherNet.